### PR TITLE
support server network interfaces other than "Ethernet"

### DIFF
--- a/server.js
+++ b/server.js
@@ -23,8 +23,22 @@ for (const name of Object.keys(nets)) {
         }
     }
 }
+const inferEthernetInterface = () => {
+    const keys = Object.keys(results)
+    for (const key of keys) {
+        if(key.startsWith("Ethernet")) {
+            return results[key]
+        }
+    }
+    return keys.length > 0
+        ? results[keys[0]]
+        : null
+}
 
-let serverAdress = results["Ethernet"][0];
+let serverAdress = (
+    results["Ethernet"] ||
+    inferEthernetInterface() ||
+    ["localhost"])[0];
 
 // create a joystick
 let deviceId = userConfig.vJoy.deviceId;


### PR DESCRIPTION
will try to use the first interface whose name starts with "Ethernet"

Otherwise will fallback to the first interface at all

the original code would throw and fail at that point